### PR TITLE
Bugfix and two PEPs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
-      language_version: python3.6
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: ''  # Use the revision sha / tag you want to point at
+    rev: 'v5.4.2'  # Use the revision sha / tag you want to point at
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
     - id: flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate travis
   - if [[ $PKGS =~ flake8 ]]; then LINT=1; else LINT=0; fi
   - if [[ $PKGS =~ sphinx ]]; then DOCS=1; else DOCS=0; fi
-  - if [[ $LINT == 0 && $DOCS == 0 ]]; then pip install serialize validators; fi
+  - if [[ $LINT == 0 && $DOCS == 0 ]]; then pip install serialize validators typing_extensions; fi
   - conda list
 
 script:

--- a/datastruct/ds.py
+++ b/datastruct/ds.py
@@ -87,6 +87,9 @@ def from_plain_value(annotation, value):
     """Convert a plain value (typically loaded from a file)
     into a DataStruct compatible value.
     """
+    # (0) Unpack the annotation if it's an Annotated[type, metadata] instance (PEP 593).
+    if isinstance(annotation, typing_ext._AnnotatedAlias):
+        annotation = annotation.__origin__
 
     # (1) The annotation is a DataStruct subclass.
     if inspect.isclass(annotation) and issubclass(annotation, DataStruct):
@@ -194,6 +197,9 @@ def to_plain_value(annotation, value):
     """Convert a value present in a DataStruct
     into a plain value (compatible with serialization/)
     """
+    # (0) Unpack the annotation if it's an Annotated[type, metadata] instance (PEP 593).
+    if isinstance(annotation, typing_ext._AnnotatedAlias):
+        annotation = annotation.__origin__
 
     # (1) The annotation is a DataStruct subclass.
     if inspect.isclass(annotation) and issubclass(annotation, DataStruct):
@@ -281,6 +287,10 @@ class DataStruct:
     def __init_subclass__(cls, **kwargs):
         errs = []
         for name, annotation in get_type_hints(cls).items():
+            # (0) Unpack the annotation if it's an Annotated[type, metadata] instance (PEP 593).
+            if isinstance(annotation, typing_ext._AnnotatedAlias):
+                annotation = annotation.__origin__
+
             if inspect.isclass(annotation) and issubclass(annotation, DataStruct):
                 continue
 

--- a/datastruct/ds.py
+++ b/datastruct/ds.py
@@ -280,7 +280,7 @@ class DataStruct:
 
     def __init_subclass__(cls, **kwargs):
         errs = []
-        for name, annotation in cls.__annotations__.items():
+        for name, annotation in get_type_hints(cls).items():
             if inspect.isclass(annotation) and issubclass(annotation, DataStruct):
                 continue
 

--- a/datastruct/ds.py
+++ b/datastruct/ds.py
@@ -395,7 +395,7 @@ class DataStruct:
 
         if ignortypes:
             return tuple(
-                exc for exc in self.__errors__ if not isinstance(exc, ignortypes)
+                exc for exc in self.__errors__ if not isinstance(exc, tuple(ignortypes))
             )
         else:
             return tuple(self.__errors__)

--- a/datastruct/test/test_base.py
+++ b/datastruct/test/test_base.py
@@ -1,5 +1,10 @@
 import typing
 
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
 from datastruct import INVALID, DataStruct, KeyDefinedValue, exceptions, validators
 
 
@@ -98,6 +103,16 @@ def test_example_default():
     o = ExampleWithDefault(dict(a=1))
     assert o.a == 1
     assert o.b == "h"
+
+
+def test_example_annotated():
+    class ExampleWithAnnotations(DataStruct):
+        a: int
+        b: Annotated[float, "metadata"]  # noqa: F821
+
+    o = ExampleWithAnnotations(dict(a=1, b=1.0))
+    assert o.a == 1
+    assert o.b == 1.0
 
 
 def test_validators():

--- a/datastruct/test/test_base.py
+++ b/datastruct/test/test_base.py
@@ -68,6 +68,10 @@ def test_missing():
     e = errs[0]
     assert e == exceptions.MissingValueError("b", Example)
 
+    errs = o.get_errors(err_on_missing=False)
+    assert isinstance(errs, tuple)
+    assert len(errs) == 0
+
 
 def test_unexpected():
 
@@ -83,6 +87,10 @@ def test_unexpected():
     assert len(errs) == 1
     e = errs[0]
     assert e == exceptions.UnexpectedKeyError("e", Example)
+
+    errs = o.get_errors(err_on_unexpected=False)
+    assert isinstance(errs, tuple)
+    assert len(errs) == 0
 
 
 def test_example_default():

--- a/datastruct/typing_ext.py
+++ b/datastruct/typing_ext.py
@@ -17,6 +17,12 @@
 
 import typing
 
+try:
+    from typing import _AnnotatedAlias  # noqa: F401
+except ImportError:
+    from typing_extensions import _AnnotatedAlias  # noqa: F401
+
+
 if hasattr(typing, "_GenericAlias"):
     # python 3.7 and 3.8
     def _is_generic(cls):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,10 @@ packages = datastruct
 zip_safe = True
 include_package_data = True
 python_requires = >=3.7
-install_requires = setuptools; serialize; validators
+install_requires =
+    serialize
+    validators
+    typing_extensions;python_version<"3.9"
 setup_requires = setuptools; setuptools_scm
 
 [options.extras_require]


### PR DESCRIPTION
- [ ] Closes # (insert issue number)
- [x] Executed ``black -t py36 . && isort -rc . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

Added test only for the bug.